### PR TITLE
Addressed ERB.new positional argument deprecation warnings in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :default => "build:all"
 desc 'Generate build-config.yml from build-config.yml.erb'
 file 'build-config.yml' => ['build-config.yml.erb'] do |t,args|
   File.open(t.name, 'w') do |fh|
-    fh << ERB.new(File.read(t.prerequisites[0]), nil, '-').result
+    fh << ERB.new(File.read(t.prerequisites[0]), trim_mode: '-').result
   end
 end
 
@@ -91,7 +91,7 @@ namespace :build do
               before_build: before_build,
               after_build:  after_build,
             }
-            fh << ERB.new(File.read(t.prerequisites[0]), nil, '-').result(binding)
+            fh << ERB.new(File.read(t.prerequisites[0]), trim_mode: '-').result(binding)
           end
           chmod "u+x", t.name
         end
@@ -140,7 +140,7 @@ namespace :test do
 
         file dockerfile[:local] => ['files/scripts/Dockerfile.erb', 'build-config.yml'] do |t, args|
           File.open(t.name, 'w') do |fh|
-            fh << ERB.new(File.read(t.prerequisites[0]), nil, '-').result(binding)
+            fh << ERB.new(File.read(t.prerequisites[0]), trim_mode: '-').result(binding)
           end
         end
 


### PR DESCRIPTION
```
% rake build-config.yml
/tmp/ruby-binary/Rakefile:40: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/tmp/ruby-binary/Rakefile:40: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```
