### PR TITLE
debian sid openssl 3.0 transition workarounds

### DIFF
--- a/build-config.yml
+++ b/build-config.yml
@@ -3,6 +3,8 @@ targets:
   - image: minimum2scp/ruby:latest
     platform: sid-amd64
     version: 2.7.6
+    openssl:
+      version: 1.1.1o
 
     envs:
       RUBY_CONFIGURE_OPTS: "--enable-load-relative"
@@ -23,6 +25,8 @@ targets:
   - image: minimum2scp/ruby:latest
     platform: sid-amd64
     version: 3.0.4
+    openssl:
+      version: 1.1.1o
 
     envs:
       RUBY_CONFIGURE_OPTS: "--enable-load-relative"

--- a/build-config.yml.erb
+++ b/build-config.yml.erb
@@ -28,10 +28,20 @@ targets:
       ruby_configure_opts = '--enable-load-relative --disable-install-doc'
     end
 
+    if platform == 'sid-amd64' && ( version == '3.0.4' || version == '2.7.6' )
+      openssl = { version: '1.1.1o' }
+    else
+      openssl = nil
+    end
+
 -%>
   - image: <%= image %>
     platform: <%= platform %>
     version: <%= version %>
+    <%- if openssl -%>
+    openssl:
+      version: <%= openssl[:version] %>
+    <%- end -%>
 
     envs:
       RUBY_CONFIGURE_OPTS: <%= ruby_configure_opts.dump %>

--- a/files/scripts/Dockerfile.erb
+++ b/files/scripts/Dockerfile.erb
@@ -2,5 +2,9 @@ FROM <%= image %>
 
 COPY <%= tarball[:local] %> /tmp/
 RUN tar xf /tmp/<%= File.basename tarball[:local] %> -C /opt/rbenv/versions
+<% if openssl %>
+COPY <%= openssl[:local] %> /tmp/
+RUN tar xf /tmp/<%= File.basename openssl[:local] %> -C /opt/
+<% end %>
 RUN bash -lc 'rbenv rehash'
 

--- a/files/scripts/build.sh.erb
+++ b/files/scripts/build.sh.erb
@@ -49,6 +49,29 @@ echo "<%= patch['file'] %>" >> /tmp/patches/series
 <% end -%>
 <% end -%>
 
+## install openssl if necessary
+<% if build_config[:openssl] -%>
+openssl_version=<%= build_config[:openssl][:version] %>
+curl -sSf -o /tmp/openssl-${openssl_version}.tar.gz https://www.openssl.org/source/openssl-${openssl_version}.tar.gz
+(
+  cd /tmp
+  tar xf openssl-${openssl_version}.tar.gz
+  cd openssl-${openssl_version}
+  ./config --prefix=/opt/openssl-${openssl_version} --openssldir=/opt/openssl-${openssl_version} shared zlib
+  make
+  make install
+  rm -rf /opt/openssl-${openssl_version}/certs
+  ln -s /etc/ssl/certs /opt/openssl-${openssl_version}
+)
+tar cfz <%= build_config[:openssl][:remote] %> -C /opt openssl-${openssl_version}
+if [ -n "${RUBY_CONFIGURE_OPTS}" ]; then
+  RUBY_CONFIGURE_OPTS="${RUBY_CONFIGURE_OPTS} --with-openssl-dir=/opt/openssl-${openssl_version}"
+else
+  RUBY_CONFIGURE_OPTS="--with-openssl-dir=/opt/openssl-${openssl_version}"
+  export RUBY_CONFIGURE_OPTS
+fi
+<% end -%>
+
 ## build and install ruby
 if [ -d /tmp/patches ]; then
   cat $(sed -e 's@^@/tmp/patches/@' /tmp/patches/series) | rbenv install --patch -k -v <%= build_config[:version] %> | tee <%= build_config[:log][:remote] %>

--- a/spec/sid-amd64_3.1.2_spec.rb
+++ b/spec/sid-amd64_3.1.2_spec.rb
@@ -1,7 +1,7 @@
 set :docker_image, "minimum2scp/ruby-binary:test_sid-amd64_3.1.2"
 
 describe "platform=sid-amd64 version=3.1.2" do
-  include_context 'openssl 1.1.1'
+  include_context 'openssl 3.0.3'
   it_behaves_like 'debian sid'
   it_behaves_like 'ruby 3.1.2'
 end

--- a/spec/support/shared_contexts/openssl.rb
+++ b/spec/support/shared_contexts/openssl.rb
@@ -2,3 +2,7 @@ RSpec.shared_context 'openssl 1.1.1' do
   let(:openssl_version){ '1.1.1' }
 end
 
+RSpec.shared_context 'openssl 3.0.3' do
+  let(:openssl_version){ '3.0.3' }
+end
+


### PR DESCRIPTION
* debian buster and bullseye: No changes. Build with system openssl (1.1.1n).
* debian sid / ruby 3.1.2: Test only changes, build with system openssl (3.0.3).
* debian sid / ruby 2.7.6 and 3.0.4: Build with openssl 1.1.1o, installed under /opt/openssl-1.1.1o.
